### PR TITLE
[CCE-1225] Upgrade dependencies and flutter version of Stripe plugin

### DIFF
--- a/packages/stripe_api/pubspec.yaml
+++ b/packages/stripe_api/pubspec.yaml
@@ -9,12 +9,12 @@ repository: https://github.com/HeadspaceMeditation/flutter-plugins/tree/master/p
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.19.0 <3.4.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  http: 0.13.6
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update dependencies of Stripe plugin to be able to update CSDK and Ginger-Flutter outdated libs