### PR TITLE
DRAFT: [MSE-178] Add `<`, `>` and `x` controls to browser for links opened in the Ada chat

### DIFF
--- a/packages/ada_chat_flutter/example/android/build.gradle
+++ b/packages/ada_chat_flutter/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/ada_chat_flutter/example/lib/ada_chat_screen.dart
+++ b/packages/ada_chat_flutter/example/lib/ada_chat_screen.dart
@@ -1,5 +1,6 @@
 import 'package:ada_chat_flutter/ada_chat_flutter.dart';
 import 'package:example/commands_menu.dart';
+import 'package:example/page_controls.dart';
 import 'package:flutter/material.dart';
 
 class AdaChatScreen extends StatefulWidget {
@@ -17,9 +18,6 @@ class AdaChatScreen extends StatefulWidget {
 class _AdaChatScreenState extends State<AdaChatScreen> {
   final _adaController = AdaController();
   var _progress = 0.0;
-  String? _title;
-  bool _goBackIsAvailable = false;
-  bool _goForwardIsAvailable = false;
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +62,12 @@ class _AdaChatScreenState extends State<AdaChatScreen> {
                     'AdaChatScreen:onAdaReady: isRolledOut=$isRolledOut');
                 setState(() => _progress = 0);
               },
-              browserController: _getBrowserController,
+              browserSettings: BrowserSettings(
+                pageBuilder: (context, browser, controller) => PageControls(
+                  controller: controller,
+                  child: browser,
+                ),
+              ),
               onLoaded: (data) =>
                   debugPrint('AdaChatScreen:onLoaded: data=$data'),
               onEvent: (event) =>
@@ -90,65 +93,6 @@ class _AdaChatScreenState extends State<AdaChatScreen> {
           ],
         ),
       ),
-    );
-  }
-
-  BrowserController get _getBrowserController {
-    return BrowserController(
-      pageBuilder: (context, browser, controls) => Stack(
-        children: [
-          browser,
-          Align(
-            alignment: Alignment.topCenter,
-            child: Row(
-              children: [
-                IconButton(
-                  icon: const Icon(Icons.arrow_back_ios),
-                  onPressed: _goBackIsAvailable ? controls.goBack : null,
-                ),
-                IconButton(
-                  icon: const Icon(Icons.arrow_forward_ios),
-                  onPressed: _goForwardIsAvailable ? controls.goForward : null,
-                ),
-                Expanded(
-                  child: Text(
-                    _title ?? '',
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context)
-                        .textTheme
-                        .headlineMedium
-                        ?.copyWith(color: Colors.green),
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close),
-                  onPressed: Navigator.of(context).pop,
-                ),
-              ],
-            ),
-          ),
-
-          // Placeholder(),
-        ],
-      ),
-      onGoBackChanged: (isAvailable) {
-        debugPrint('@@@ onGoBackChanged: isAvailable=$isAvailable');
-        setState(() {
-          _goBackIsAvailable = isAvailable;
-        });
-      },
-      onGoForwardChanged: (isAvailable) {
-        debugPrint('@@@ onGoForwardChanged: isAvailable=$isAvailable');
-        setState(() {
-          _goForwardIsAvailable = isAvailable;
-        });
-      },
-      onTitleChanged: (text) {
-        debugPrint('@@@ onTitleChanged: text=$text');
-        setState(() {
-          _title = text;
-        });
-      },
     );
   }
 

--- a/packages/ada_chat_flutter/example/lib/ada_chat_screen.dart
+++ b/packages/ada_chat_flutter/example/lib/ada_chat_screen.dart
@@ -17,6 +17,9 @@ class AdaChatScreen extends StatefulWidget {
 class _AdaChatScreenState extends State<AdaChatScreen> {
   final _adaController = AdaController();
   var _progress = 0.0;
+  String? _title;
+  bool _goBackIsAvailable = false;
+  bool _goForwardIsAvailable = false;
 
   @override
   Widget build(BuildContext context) {
@@ -61,6 +64,7 @@ class _AdaChatScreenState extends State<AdaChatScreen> {
                     'AdaChatScreen:onAdaReady: isRolledOut=$isRolledOut');
                 setState(() => _progress = 0);
               },
+              browserController: _getBrowserController,
               onLoaded: (data) =>
                   debugPrint('AdaChatScreen:onLoaded: data=$data'),
               onEvent: (event) =>
@@ -86,6 +90,65 @@ class _AdaChatScreenState extends State<AdaChatScreen> {
           ],
         ),
       ),
+    );
+  }
+
+  BrowserController get _getBrowserController {
+    return BrowserController(
+      pageBuilder: (context, browser, controls) => Stack(
+        children: [
+          browser,
+          Align(
+            alignment: Alignment.topCenter,
+            child: Row(
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.arrow_back_ios),
+                  onPressed: _goBackIsAvailable ? controls.goBack : null,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.arrow_forward_ios),
+                  onPressed: _goForwardIsAvailable ? controls.goForward : null,
+                ),
+                Expanded(
+                  child: Text(
+                    _title ?? '',
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context)
+                        .textTheme
+                        .headlineMedium
+                        ?.copyWith(color: Colors.green),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: Navigator.of(context).pop,
+                ),
+              ],
+            ),
+          ),
+
+          // Placeholder(),
+        ],
+      ),
+      onGoBackChanged: (isAvailable) {
+        debugPrint('@@@ onGoBackChanged: isAvailable=$isAvailable');
+        setState(() {
+          _goBackIsAvailable = isAvailable;
+        });
+      },
+      onGoForwardChanged: (isAvailable) {
+        debugPrint('@@@ onGoForwardChanged: isAvailable=$isAvailable');
+        setState(() {
+          _goForwardIsAvailable = isAvailable;
+        });
+      },
+      onTitleChanged: (text) {
+        debugPrint('@@@ onTitleChanged: text=$text');
+        setState(() {
+          _title = text;
+        });
+      },
     );
   }
 

--- a/packages/ada_chat_flutter/example/lib/page_controls.dart
+++ b/packages/ada_chat_flutter/example/lib/page_controls.dart
@@ -1,0 +1,78 @@
+import 'dart:ui';
+
+import 'package:ada_chat_flutter/ada_chat_flutter.dart';
+import 'package:flutter/material.dart';
+
+class PageControls extends StatefulWidget {
+  const PageControls({
+    super.key,
+    required this.controller,
+    required this.child,
+  });
+
+  final BrowserController controller;
+  final Widget child;
+
+  @override
+  State<PageControls> createState() => _PageControlsState();
+}
+
+class _PageControlsState extends State<PageControls> {
+  @override
+  void initState() {
+    super.initState();
+
+    widget.controller.addListener(_rebuild);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_rebuild);
+
+    super.dispose();
+  }
+
+  void _rebuild() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) => Stack(
+        children: [
+          widget.child,
+          Align(
+            alignment: Alignment.topCenter,
+            child: ClipRect(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
+                child: Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back_ios),
+                      onPressed: widget.controller.backIsAvailable
+                          ? widget.controller.goBack
+                          : null,
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.arrow_forward_ios),
+                      onPressed: widget.controller.forwardIsAvailable
+                          ? widget.controller.goForward
+                          : null,
+                    ),
+                    Expanded(
+                      child: Text(
+                        widget.controller.title,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.headlineMedium,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: Navigator.of(context).pop,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+}

--- a/packages/ada_chat_flutter/lib/ada_chat_flutter.dart
+++ b/packages/ada_chat_flutter/lib/ada_chat_flutter.dart
@@ -3,4 +3,5 @@ library ada_chat_flutter;
 export 'src/ada_controller.dart';
 export 'src/ada_exception.dart';
 export 'src/ada_web_view.dart';
+export 'src/browser_controller.dart';
 export 'src/test/mock_web_view_dependencies.dart';

--- a/packages/ada_chat_flutter/lib/ada_chat_flutter.dart
+++ b/packages/ada_chat_flutter/lib/ada_chat_flutter.dart
@@ -1,5 +1,7 @@
 library ada_chat_flutter;
 
+export 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
 export 'src/ada_controller.dart';
 export 'src/ada_exception.dart';
 export 'src/ada_web_view.dart';

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -142,7 +142,7 @@ class _AdaWebViewState extends State<AdaWebView> {
         : 'packages/ada_chat_flutter/assets/embed.html';
   }
 
-  Future<void> _start(controller, url) async {
+  Future<void> _start(InAppWebViewController controller, WebUri? url) async {
     final metaFields = {
       ...widget.metaFields,
       'sdkType': getOsName,
@@ -219,7 +219,7 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
     );
   }
 
-  Future<void> _init(controller) async {
+  Future<void> _init(InAppWebViewController controller) async {
     widget.controller?.init(
       webViewController: controller,
       handle: widget.handle,

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -282,7 +282,8 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
     NavigationAction navigationAction,
   ) async {
     final url = navigationAction.request.url;
-    print('@@@ url=$url, host=${url?.host}');
+    debugPrint('@@@ url=$url, host=${url?.host}');
+
     if (url == null ||
         url.toString() == 'about:blank' ||
         url.toString() == widget.urlRequest?.url.toString() ||

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -285,6 +285,7 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
     print('@@@ url=$url, host=${url?.host}');
     if (url == null ||
         url.toString() == 'about:blank' ||
+        url.toString() == widget.urlRequest?.url.toString() ||
         url.toString().endsWith('/ada_chat_flutter/assets/embed.html') ||
         url.host == '${widget.handle}.ada.support') {
       return NavigationActionPolicy.ALLOW;
@@ -303,8 +304,6 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
             initialSettings: settings,
             onLoadStop: (InAppWebViewController controller, WebUri? url) async {
               widget.browserSettings?._control.init(controller);
-
-              print('@@@ onLoadStop: url=$url');
 
               final title = await controller.getTitle();
               widget.browserSettings?._control.setTitle(title ?? '');

--- a/packages/ada_chat_flutter/lib/src/browser_controller.dart
+++ b/packages/ada_chat_flutter/lib/src/browser_controller.dart
@@ -1,46 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
-/// User's method to wrap the browser widget in a custom user's page
-///
-/// context - Current context
-/// browser - Browser widget that is opened by the Ada chat
-/// controls - Controls for browser widget
-typedef PageBuilder = Widget Function(
-  BuildContext context,
-  Widget browser,
-  BrowserControls controls,
-);
-
 typedef BooleanCallback = void Function(bool isAvailable);
 typedef StringCallback = void Function(String text);
 
-class BrowserInit {
+class BrowserController extends ChangeNotifier {
   InAppWebViewController? _controller;
+  String _title = '';
+  bool _backIsAvailable = false;
+  bool _forwardIsAvailable = false;
 
-  set controller(InAppWebViewController controller) => _controller = controller;
-}
+  void init(InAppWebViewController controller) => _controller = controller;
 
-class BrowserControls extends BrowserInit {
   Future<void> goBack() async => _controller?.goBack();
 
   Future<void> goForward() async => _controller?.goForward();
-}
 
-class BrowserController extends BrowserControls {
-  BrowserController({
-    required this.pageBuilder,
-    this.onTitleChanged,
-    this.onGoBackChanged,
-    this.onGoForwardChanged,
-  });
+  String get title => _title;
+  void setTitle(String text) {
+    _title = text;
+    notifyListeners();
+  }
 
-  /// Custom page builder
-  final PageBuilder pageBuilder;
+  bool get backIsAvailable => _backIsAvailable;
+  void setBackIsAvailable(bool isAvailable) {
+    _backIsAvailable = isAvailable;
+    notifyListeners();
+  }
 
-  final StringCallback? onTitleChanged;
-
-  final BooleanCallback? onGoBackChanged;
-
-  final BooleanCallback? onGoForwardChanged;
+  bool get forwardIsAvailable => _forwardIsAvailable;
+  void setForwardIsAvailable(bool isAvailable) {
+    _forwardIsAvailable = isAvailable;
+    notifyListeners();
+  }
 }

--- a/packages/ada_chat_flutter/lib/src/browser_controller.dart
+++ b/packages/ada_chat_flutter/lib/src/browser_controller.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+/// User's method to wrap the browser widget in a custom user's page
+///
+/// context - Current context
+/// browser - Browser widget that is opened by the Ada chat
+/// controls - Controls for browser widget
+typedef PageBuilder = Widget Function(
+  BuildContext context,
+  Widget browser,
+  BrowserControls controls,
+);
+
+typedef BooleanCallback = void Function(bool isAvailable);
+typedef StringCallback = void Function(String text);
+
+class BrowserInit {
+  InAppWebViewController? _controller;
+
+  set controller(InAppWebViewController controller) => _controller = controller;
+}
+
+class BrowserControls extends BrowserInit {
+  Future<void> goBack() async => _controller?.goBack();
+
+  Future<void> goForward() async => _controller?.goForward();
+}
+
+class BrowserController extends BrowserControls {
+  BrowserController({
+    required this.pageBuilder,
+    this.onTitleChanged,
+    this.onGoBackChanged,
+    this.onGoForwardChanged,
+  });
+
+  /// Custom page builder
+  final PageBuilder pageBuilder;
+
+  final StringCallback? onTitleChanged;
+
+  final BooleanCallback? onGoBackChanged;
+
+  final BooleanCallback? onGoForwardChanged;
+}

--- a/packages/ada_chat_flutter/pubspec.yaml
+++ b/packages/ada_chat_flutter/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
     sdk: flutter
   flutter_inappwebview: ^6.0.0
   meta: ^1.8.0
+  mocktail: ^1.0.3 # Used by MockWebViewDependencies() tests helper
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-  mocktail: ^1.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Add option to customize internal browser look

<img width="522" alt="image" src="https://github.com/HeadspaceMeditation/flutter-plugins/assets/142573395/9d9b40bd-41b0-4cd3-866b-19432891a020">
