### PR TITLE
[MSE-178] Add `<`, `>` and `x` controls to browser pt.2

### DIFF
--- a/packages/ada_chat_flutter/CHANGELOG.md
+++ b/packages/ada_chat_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Add host and isHttp fields to the browser controller.
+
 ## 0.0.3
 
 - Add browserSettings with webview page builder.

--- a/packages/ada_chat_flutter/example/lib/main.dart
+++ b/packages/ada_chat_flutter/example/lib/main.dart
@@ -13,6 +13,9 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp(
+        theme: ThemeData.light(useMaterial3: false),
+        darkTheme: ThemeData.dark(useMaterial3: false),
+        themeMode: ThemeMode.system,
         onGenerateRoute: (route) {
           switch (route.name) {
             case '/ada':

--- a/packages/ada_chat_flutter/example/lib/main.dart
+++ b/packages/ada_chat_flutter/example/lib/main.dart
@@ -13,8 +13,17 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp(
-        theme: ThemeData.light(useMaterial3: false),
-        darkTheme: ThemeData.dark(useMaterial3: false),
+        theme: ThemeData.from(
+          colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.orange),
+          useMaterial3: false,
+        ),
+        darkTheme: ThemeData.from(
+          colorScheme: ColorScheme.fromSwatch(
+            primarySwatch: Colors.orange,
+            brightness: Brightness.dark,
+          ),
+          useMaterial3: false,
+        ),
         themeMode: ThemeMode.system,
         onGenerateRoute: (route) {
           switch (route.name) {

--- a/packages/ada_chat_flutter/example/lib/screens/ada_chat_screen.dart
+++ b/packages/ada_chat_flutter/example/lib/screens/ada_chat_screen.dart
@@ -62,10 +62,13 @@ class _AdaChatScreenState extends State<AdaChatScreen> {
                   setState(() => _progress = 0);
                 },
                 browserSettings: BrowserSettings(
-                  pageBuilder: (context, browser, controller) =>
-                      PageWithControls(
-                    controller: controller,
-                    child: browser,
+                  pageBuilder: (context, browser, controller) => Scaffold(
+                    body: SafeArea(
+                      child: PageWithControls(
+                        controller: controller,
+                        child: browser,
+                      ),
+                    ),
                   ),
                 ),
                 onLoaded: (data) =>

--- a/packages/ada_chat_flutter/example/lib/webview_controls/page_controls.dart
+++ b/packages/ada_chat_flutter/example/lib/webview_controls/page_controls.dart
@@ -56,10 +56,30 @@ class _PageControlsState extends State<PageControls> {
                 onPressed: widget.controller.reload,
               ),
               Expanded(
-                child: Text(
-                  widget.controller.title,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodySmall,
+                child: Column(
+                  children: [
+                    Text(
+                      widget.controller.title,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    Row(
+                      children: [
+                        Icon(
+                          widget.controller.isHttps
+                              ? Icons.lock
+                              : Icons.lock_open,
+                          size: 10,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          widget.controller.host,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
               ),
               IconButton(

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -310,6 +310,7 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
     unawaited(
       showDialog(
         context: context,
+        barrierColor: Colors.transparent,
         builder: (context) => CustomizedWebView(
           url: url,
           browserSettings: widget.browserSettings,

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -311,13 +311,9 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
       showAdaptiveDialog(
         context: context,
         barrierColor: Colors.transparent,
-        builder: (context) => SafeArea(
-          child: Scaffold(
-            body: CustomizedWebView(
-              url: url,
-              browserSettings: widget.browserSettings,
-            ),
-          ),
+        builder: (context) => CustomizedWebView(
+          url: url,
+          browserSettings: widget.browserSettings,
         ),
         useRootNavigator: false,
       ),

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -311,9 +311,13 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
       showAdaptiveDialog(
         context: context,
         barrierColor: Colors.transparent,
-        builder: (context) => CustomizedWebView(
-          url: url,
-          browserSettings: widget.browserSettings,
+        builder: (context) => SafeArea(
+          child: Scaffold(
+            body: CustomizedWebView(
+              url: url,
+              browserSettings: widget.browserSettings,
+            ),
+          ),
         ),
         useRootNavigator: false,
       ),

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -308,9 +308,9 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
     }
 
     unawaited(
-      showDialog(
+      showAdaptiveDialog(
         context: context,
-        barrierColor: Colors.white70,
+        barrierColor: Colors.transparent,
         builder: (context) => CustomizedWebView(
           url: url,
           browserSettings: widget.browserSettings,

--- a/packages/ada_chat_flutter/lib/src/ada_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/ada_web_view.dart
@@ -310,7 +310,7 @@ console.log("adaSettings: " + JSON.stringify(window.adaSettings));
     unawaited(
       showDialog(
         context: context,
-        barrierColor: Colors.transparent,
+        barrierColor: Colors.white70,
         builder: (context) => CustomizedWebView(
           url: url,
           browserSettings: widget.browserSettings,

--- a/packages/ada_chat_flutter/lib/src/browser_controller.dart
+++ b/packages/ada_chat_flutter/lib/src/browser_controller.dart
@@ -4,6 +4,8 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 class BrowserController extends ChangeNotifier {
   InAppWebViewController? _controller;
   String _title = '';
+  String _host = '';
+  bool _isHttps = true;
   bool _backIsAvailable = false;
   bool _forwardIsAvailable = false;
 
@@ -19,6 +21,20 @@ class BrowserController extends ChangeNotifier {
 
   void setTitle(String text) {
     _title = text;
+    notifyListeners();
+  }
+
+  String get host => _host;
+
+  void setHost(String host) {
+    _host = host;
+    notifyListeners();
+  }
+
+  bool get isHttps => _isHttps;
+
+  void setIsHttps(bool isHttps) {
+    _isHttps = isHttps;
     notifyListeners();
   }
 

--- a/packages/ada_chat_flutter/lib/src/customized_web_view.dart
+++ b/packages/ada_chat_flutter/lib/src/customized_web_view.dart
@@ -51,6 +51,11 @@ class _CustomizedWebViewState extends State<CustomizedWebView> {
         final title = await webViewController.getTitle();
         widget.browserSettings?.control?.setTitle(title ?? '');
 
+        final webUri = await webViewController.getUrl();
+        widget.browserSettings?.control?.setHost(webUri?.host ?? '');
+        widget.browserSettings?.control
+            ?.setIsHttps(webUri?.isScheme('https') ?? false);
+
         final canGoBack = await webViewController.canGoBack();
         widget.browserSettings?.control?.setBackIsAvailable(canGoBack);
 

--- a/packages/ada_chat_flutter/pubspec.yaml
+++ b/packages/ada_chat_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ada_chat_flutter
 description: Flutter implementation of Ada chat
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/packages/ada_chat_flutter/test/src/browser_controller_test.dart
+++ b/packages/ada_chat_flutter/test/src/browser_controller_test.dart
@@ -42,6 +42,19 @@ void main() {
       expect(browserController.title, newTitle);
     });
 
+    test('host getter returns correct value', () {
+      const newHost = 'New Host';
+      browserController.setHost(newHost);
+      expect(browserController.host, newHost);
+    });
+
+    test('isHttps getter returns correct value', () {
+      browserController.setIsHttps(false);
+      expect(browserController.isHttps, false);
+      browserController.setIsHttps(true);
+      expect(browserController.isHttps, true);
+    });
+
     test('backIsAvailable getter returns correct value', () {
       browserController.setBackIsAvailable(true);
       expect(browserController.backIsAvailable, true);
@@ -57,10 +70,12 @@ void main() {
       browserController.addListener(() => listenerCallCount++);
 
       browserController.setTitle('New Title');
+      browserController.setHost('New Host');
+      browserController.setIsHttps(false);
       browserController.setBackIsAvailable(true);
       browserController.setForwardIsAvailable(false);
 
-      expect(listenerCallCount, 3);
+      expect(listenerCallCount, 5);
     });
   });
 }


### PR DESCRIPTION
Add `<`, `>` and `x` controls to browser for links opened in the Ada chat

Part 2

Add host and https check.

[MSE-178](https://headspace.atlassian.net/browse/MSE-178)

<img width="534" alt="image" src="https://github.com/HeadspaceMeditation/flutter-plugins/assets/142573395/edab09e5-9067-48ae-9cc0-7374f95e19e0">


[MSE-178]: https://headspace.atlassian.net/browse/MSE-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ